### PR TITLE
[commen] Update ANTLR to Version 4.13.2 and remove the testing of ANTLR

### DIFF
--- a/src/common/parser/build.gradle
+++ b/src/common/parser/build.gradle
@@ -31,7 +31,7 @@ plugins {
 
 description 'Grammar Parser (ANTLR)'
 
-def antlr4Version = "4.12.0"
+def antlr4Version = "4.13.2"
 
 
 task downloadAntlr4(type: Download) {
@@ -67,9 +67,9 @@ task compileAntlr4(dependsOn: unzipAntlr4) {
 		exec {
 			workingDir "antlr4/antlr4-cpp-runtime-${antlr4Version}-source/.cmake"
 			if (System.properties['os.name'].toLowerCase().contains('windows')) {
-				commandLine 'cmd', '/c', 'cmake -G "MinGW Makefiles" -DCMAKE_CXX_STANDARD:STRING=17 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=' + file("./antlr4/bin") + ' ' + file("./antlr4/antlr4-cpp-runtime-${antlr4Version}-source").absolutePath
+				commandLine 'cmd', '/c', 'cmake -G "MinGW Makefiles" -DANTLR_BUILD_CPP_TESTS=OFF -DCMAKE_CXX_STANDARD:STRING=17 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=' + file("./antlr4/bin") + ' ' + file("./antlr4/antlr4-cpp-runtime-${antlr4Version}-source").absolutePath
 			} else {
-				commandLine '/bin/sh', '-c', 'cmake -G "Unix Makefiles" -DCMAKE_CXX_STANDARD:STRING=17 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=' + file("./antlr4/bin") + ' ' + file("./antlr4/antlr4-cpp-runtime-${antlr4Version}-source").absolutePath
+				commandLine '/bin/sh', '-c', 'cmake -G "Unix Makefiles" -DANTLR_BUILD_CPP_TESTS=OFF -DCMAKE_CXX_STANDARD:STRING=17 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=' + file("./antlr4/bin") + ' ' + file("./antlr4/antlr4-cpp-runtime-${antlr4Version}-source").absolutePath
 			}
 		}
 		exec {


### PR DESCRIPTION
The current inclusion of GoogleTest via ANTLR introduces build issues. The ANTLR CMake configuration requires CMake ≥ 3.15, while GoogleTest is compatible with much older CMake versions (around 2.8.12) and relies on features from versions earlier than 3.5. This mismatch leads to configuration and dependency conflicts.

Additionally, ANTLR’s unit tests are not being executed in our build process and are unlikely to be required for our use case. Therefore, ANTLR can be built without enabling its unit test suite.

Disabling ANTLR unit tests resolves the issue by preventing GoogleTest from being included entirely, eliminating the dependency conflict.

<!-- gk-ai-analysis-start:064bfd368221b2fc7aafdb9a0e320e319919ad3d -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiVXBkYXRlcyBBTlRMUiB0byB2ZXJzaW9uIDQuMTMuMiBhbmQgZGlzYWJsZXMgaXRzIGludGVybmFsIEMrKyB1bml0IHRlc3RzIHRvIHJlc29sdmUgQ01ha2UgdmVyc2lvbiBjb25mbGljdHMgd2l0aCBHb29nbGVUZXN0LiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IkFOVExSIHZlcnNpb24gdXBkYXRlIiwiZGVzY3JpcHRpb24iOiJUaGUgQU5UTFIgdmVyc2lvbiBoYXMgYmVlbiBidW1wZWQgZnJvbSA0LjEyLjAgdG8gNC4xMy4yLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJzcmMvY29tbW9uL3BhcnNlci9idWlsZC5ncmFkbGUiLCJsaW5lU3RhcnQiOjM0fSx7InRpdGxlIjoiRGlzYWJsZWQgQU5UTFIgdW5pdCB0ZXN0cyIsImRlc2NyaXB0aW9uIjoiQWRkZWQgYC1EQU5UTFJfQlVJTERfQ1BQX1RFU1RTPU9GRmAgdG8gdGhlIENNYWtlIGNvbmZpZ3VyYXRpb24gdG8gc2tpcCBidWlsZGluZyBBTlRMUidzIHVuaXQgdGVzdHMsIHByZXZlbnRpbmcgZGVwZW5kZW5jeSBjb25mbGljdHMgd2l0aCBHb29nbGVUZXN0IG9uIGJvdGggV2luZG93cyBhbmQgVW5peCBlbnZpcm9ubWVudHMuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6InNyYy9jb21tb24vcGFyc2VyL2J1aWxkLmdyYWRsZSIsImxpbmVTdGFydCI6NzAsImxpbmVFbmQiOjcyfV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:064bfd368221b2fc7aafdb9a0e320e319919ad3d -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/MDE4CPP/MDE4CPP/pull/48?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->